### PR TITLE
fix npm publish package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,23 @@
 # We don't need any of the demo stuff in the NPM package
-./src/demos/
+src/demos
 
 # We don't need the testing stuff in the NPM package
-./cypress/
-./src/__tests__/
-./dist/__tests__/
+cypress
+src/__tests__
 
 # Nor do we need any of the styleguidist stuff from the core
-./styleguide.*
-./src/**/*.md
+styleguide.*
+src/**/*.md
 
 # Nor do we need some of the extra stuff
-./scripts/
-./makeNoticeList.py
-./noticeList.txt
+scripts
+cypress.json
+makeNoticeList.py
+noticeList.txt
+.github
+bin
+.babelrc
+.eslintrc
+.gitattributes
+.travis.yml
+.yalcignore

--- a/package.json
+++ b/package.json
@@ -84,9 +84,6 @@
     "not op_mini all"
   ],
   "main": "dist/index.js",
-  "files": [
-    "dist/*"
-  ],
   "jest": {
     "collectCoverageFrom": [
       "src/core/**.{js,jsx,ts}",


### PR DESCRIPTION
After reading this: https://github.com/yarnpkg/yarn/issues/685

I experimented using the `yarn pack` command. It now produces a package that only contains 48 files/directories instead of the thousands it had before.

The changes are these:
- changes to the syntax used in `.npmignore`
- additions to the same (in order to fit well with `.gitignore`)
- removal of the "files" section in `package.json`

I do not know why the last one exists in the first place. So you may want to publish a beta first and what ends up in NPM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/uw-content-validation/112)
<!-- Reviewable:end -->
